### PR TITLE
config: remove space from plugin name

### DIFF
--- a/Info.lua
+++ b/Info.lua
@@ -1,35 +1,35 @@
-g_PluginInfo = 
+g_PluginInfo =
 {
-	Name = "Portal v2",
+	Name = "Portal-v2",
 	Version = "2.0.4",
 	Date = "2015-11-09",
 	SourceLocation = "https://github.com/jonnyboy0719/Cuberite-Portal/",
 	Description = [[Create portals to other places on the world, or to other worlds!]],
-	
+
 	Commands =
 	{
-		["/ptoggle"] = 
+		["/ptoggle"] =
 		{
 			Permission = "portal.create",
 			Handler = HandleToggleCommand,
 			HelpString = "Switches to volume selection mode",
 		},
 
-		["/pwarp"] = 
+		["/pwarp"] =
 		{
 			Permission = "portal.create",
 			Handler = HandleMakeWarpCommand,
 			HelpString = "Creates warp point with given name",
 		},
 
-		["/penter"] = 
+		["/penter"] =
 		{
 			Permission = "portal.create",
 			Handler = HandleMakeEnterCommand,
 			HelpString = "Connects 2 portals together",
 		},
-		
-		["/pdest"] = 
+
+		["/pdest"] =
 		{
 			Permission = "portal.create",
 			Handler = HandleMakeDestinationCommand,


### PR DESCRIPTION
The cuberite web admin uses the plugin name in the path
for plugin pages. It appears the space is breaking links
so this removes that

Sorry about the trailing spaces. If you care about that I can remove them the same for the dash, I can remove that if you want too.

As my commit messages says it appears that maybe the router for the web admin has an issue with the space in the url path, Im guessing a problem with unescaping the space?? anyways removing the space is the easiest way to ensure this never happens
